### PR TITLE
fix: modify to correct compo name for contains with repeating types

### DIFF
--- a/FROM_TEST_SUIT.MD
+++ b/FROM_TEST_SUIT.MD
@@ -121,7 +121,7 @@
 
 1. Upload `type_repetition_conformance_ehrbase.org.opt` if not exist
 2. Create ehr
-3. Create composition `aql-conformance-ehrbase.org.v0_contains.json`
+3. Create composition `type_repetition_conformance_ehrbase.org_one_reptation.json`
 4. Run Query 'Select `SELECT o FROM COMPOSITION contains {from}`
 
    | from                                | expected result                                                                                                         |


### PR DESCRIPTION
On: https://github.com/ehrbase/AQL_Test_CASES/blob/main/FROM_TEST_SUIT.MD#contains-with-repeating-types
Rename from: aql-conformance-ehrbase.org.v0_contains.json
To: type_repetition_conformance_ehrbase.org_one_reptation.json