### PR TITLE
fix: modify AQL WHERE - Compare with extracted column II

### DIFF
--- a/WHERE_TEST_SUIT.md
+++ b/WHERE_TEST_SUIT.md
@@ -33,8 +33,7 @@
 4. Run Query 'Select `SELECT o FROM COMPOSITION contains OBSERVATION o where {where}`
 
 | {where}                                                                    | o/uid/value                                                                     |
-|----------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| o/uid/value = "94c0e756-e892-4985-884b-46829605a236"                       | Returns 1 observation with o/uid/value = "94c0e756-e892-4985-884b-46829605a236"                                          |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------|                                        |
 | o/archetype_node_id = "openEHR-EHR-OBSERVATION.conformance_observation.v0" | Returns 2 observations with o/uid/value = ["94c0e756-e892-4985-884b-46829605a236","d4cccdfc-9c90-402f-b4bb-94e8dc4ea429"] |
 | o/name/value = "Blood pressure"                                            | Returns 1 observation with o/uid/value = "2183807d-af68-41c5-9bfe-28cd150d62f7"                                          |
 


### PR DESCRIPTION
fix: modify AQL and expected results for WHERE, Compare with extracted column II
AQL FROM: SELECT **o/uid/value** FROM COMPOSITION contains OBSERVATION o where {where}
AQL TO: SELECT **o** FROM COMPOSITION contains OBSERVATION o where {where}